### PR TITLE
feat:(ignoreValues): Adding flag for single-stage validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ should be expressed using the [quantity
 definitions](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
 of Kubernetes.
 
+If you would only like to enforce that requests and limits are set (ie, you do not care
+what they are set to, just that they have been set), you can set `ignoreValues` to `true`.
+This will skip the enforcement of specific values and only enforce that requests and
+limits are set. Here is an example of how to configure this:
+
+```yaml
+# optional
+memory:
+  ignoreValues: true
+# optional
+cpu:
+  defaultRequest: 100m
+  defaultLimit: 200m
+  maxLimit: 500m
+# optional
+ignoreImages: ["ghcr.io/foo/bar:1.23", "myimage", "otherimages:v1"]
+```
+
+Please note from the above example, that when `ignoreValues` is set to `true`, the
+`defaultRequest`, `defaultLimit`, and `maxLimit` fields must not be set. Additionally,
+`ignoreValues` default value is `false`, so it's recommended to only provide it when
+you want to set it to `true`.
+
 Any container that uses an image that matches an entry in this list will be excluded
 from enforcement.
 

--- a/test_data/pod_without_resources.json
+++ b/test_data/pod_without_resources.json
@@ -1,0 +1,58 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "group": "",
+    "kind": "Pod",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "",
+    "version": "v1",
+    "resource": "pods"
+  },
+  "requestKind": {
+    "group": "",
+    "version": "v1",
+    "kind": "Pod"
+  },
+  "requestResource": {
+    "group": "",
+    "version": "v1",
+    "resource": "pods"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "operation": "CREATE",
+  "userInfo": {
+    "username": "kubernetes-admin",
+    "groups": [
+      "system:masters",
+      "system:authenticated"
+    ]
+  },
+  "object": {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "name": "test-pod",
+      "namespace": "default",
+      "labels": {
+        "cc-center": "123",
+        "owner": "team-alpha"
+      }
+    },
+    "spec": {
+      "containers": [
+        {
+          "name": "pause",
+          "image": "registry.k8s.io/pause"
+        },
+        {
+          "name": "mycontainer",
+          "image": "image:latest"
+
+        }
+      ]
+    }
+  }
+}

--- a/validate.go
+++ b/validate.go
@@ -94,6 +94,8 @@ func validateAndAdjustContainerResourceRequests(container *corev1.Container, set
 	return mutated
 }
 
+// validateAndAdjustContainerResourceLimit validates the container against the passed resourceConfig // and mutates it if the validation didn't pass.
+// Returns true when it mutates the container.
 func validateAndAdjustContainerResourceLimit(container *corev1.Container, resourceName string, resourceConfig *ResourceConfiguration) (bool, error) {
 	if missingResourceQuantity(container.Resources.Limits, resourceName) {
 		if !resourceConfig.DefaultLimit.IsZero() {

--- a/validate.go
+++ b/validate.go
@@ -77,7 +77,6 @@ func validateContainerResources(container *corev1.Container, settings *Settings)
 		return err
 	}
 	return nil
-
 }
 
 // When the CPU/Memory request is specified: no action or check is done against it.
@@ -116,8 +115,16 @@ func validateAndAdjustContainerResourceLimit(container *corev1.Container, resour
 	return false, nil
 }
 
-// When the CPU/Memory limit is specified: the request is accepted if the limit defined by the container is less than or equal to the `maxLimit`. Otherwise the request is rejected.
-// When the CPU/Memory limit is not specified: the container is mutated to use the `defaultLimit`.
+// validateAndAdjustContainerResourceLimits validates the container and mutates
+// it when possible, when it doesn't pass validation.
+//
+// When the CPU/Memory limit is specified: the request is accepted if the limit
+// defined by the container is less than or equal to the `maxLimit`, or
+// IgnoreValues is true. Otherwise the request is rejected.
+//
+// When the CPU/Memory limit is not specified: the container is mutated to use
+// the `defaultLimit`.
+//
 // Return `true` when the container has been mutated.
 func validateAndAdjustContainerResourceLimits(container *corev1.Container, settings *Settings) (bool, error) {
 	mutated := false
@@ -164,7 +171,6 @@ func validateAndAdjustContainer(container *corev1.Container, settings *Settings)
 	}
 	requestsMutation := validateAndAdjustContainerResourceRequests(container, settings)
 	return limitsMutation || requestsMutation, nil
-
 }
 
 func shouldSkipContainer(image string, ignoreImages []string) bool {
@@ -200,7 +206,6 @@ func validatePodSpec(pod *corev1.PodSpec, settings *Settings) (bool, error) {
 		mutated = mutated || containerMutated
 	}
 	return mutated, nil
-
 }
 
 func validate(payload []byte) ([]byte, error) {


### PR DESCRIPTION
This PR introduces a new configuration setting for both `cpu` and `memory` settings: `ignoreValues`

## Description
The purpose of this addition is to support enforcing that `cpu` and `memory` configuration is set, without actually caring what it is set to.

In my example (why I wanted this feature), is we enforce `cpu` and `memory` limits via [Rancher](https://www.rancher.com/) at the `project` and `namespace` level, and as a best practice, simply want to enforce that our dev teams are configuring these themselves as a best practice but we do not care what they set them to.

Fix #17 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
make e2e-tests
```

## Additional Information


### Potential improvement

This allows this policy to be used in many more scenarios without taking away from it's original / core purpose and functionality.
