### PR TITLE
fix(ci): publish artifacthub files in a dedicated branch.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,17 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ghcr.io/${{ github.repository_owner }}/policies/container-resources
+
+  push-artifacthub:
+      # skip when releasing :latest from main, versions will not match
+      if: startsWith(github.ref, 'refs/tags/v')
+      needs: release
+      permissions:
+        # Give the default GITHUB_TOKEN write permission to commit and push the
+        # added or changed files to the repository.
+        contents: write
+      runs-on: ubuntu-latest
+      steps:
+        -
+          name: Push artifacthub files to artifacthub branch
+          uses: kubewarden/github-actions/push-artifacthub@v3.1.18


### PR DESCRIPTION
## Description

Kubewarden policies should published the ArtifactHub files in a dedicated branch to avoid timing issues with the cronjob which check for new releases. Therefore, we avoid the issue of having the policy missing the "signed" flag in the ArtifactHub website.


Fix #15 
