### PR TITLE
chore: bump 0.2.1 version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,32 +4,32 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.0
+version: 0.2.1
 name: container-resources
 displayName: Container Resources
-createdAt: 2024-03-14T15:31:03.884823532Z
+createdAt: 2024-03-15T16:54:22.203018804Z
 description: Policy is designed to enforce constraints on the resource requirements of Kubernetes containers
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/container-resources-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/container-resources:v0.2.0
+  image: ghcr.io/kubewarden/policies/container-resources:v0.2.1
 keywords:
 - container
 - resources
 links:
 - name: policy
-  url: https://github.com/kubewarden/container-resources-policy/releases/download/v0.2.0/policy.wasm
+  url: https://github.com/kubewarden/container-resources-policy/releases/download/v0.2.1/policy.wasm
 - name: source
   url: https://github.com/kubewarden/container-resources-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/container-resources:v0.2.0
+  kwctl pull ghcr.io/kubewarden/policies/container-resources:v0.2.1
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/container-resources:v0.2.0
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/container-resources:v0.2.1
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Bumps to version v0.2.1 to release the fixes necessary to show the policy as "signed" in the ArtifactHub website.


Related to #15 
