### PR TITLE
fix: check limits mutation.

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -74,8 +74,8 @@ func (s *Settings) Valid() error {
 	}
 	if cpuError != nil || memoryError != nil {
 		// user want to validate only one type of resource. The other one should be ignored
-		if (cpuError == nil && errors.Is(memoryError, AllValuesAreZeroError{})) || (memoryError == nil && errors.Is(cpuError, AllValuesAreZeroError{})) { 
-			return  nil
+		if (cpuError == nil && errors.Is(memoryError, AllValuesAreZeroError{})) || (memoryError == nil && errors.Is(cpuError, AllValuesAreZeroError{})) {
+			return nil
 		}
 		return errors.Join(cpuError, memoryError)
 	}

--- a/test_data/deployment_with_requests_no_limit_resources_admission_request.json
+++ b/test_data/deployment_with_requests_no_limit_resources_admission_request.json
@@ -1,0 +1,178 @@
+{
+  "dryRun": false,
+  "kind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "annotations": {
+        "io.kubewarden.policy.echo.create": "true",
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":0,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:latest\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
+      },
+      "creationTimestamp": "2024-01-11T12:25:50Z",
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "apps/v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:io.kubewarden.policy.echo.create": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              "f:progressDeadlineSeconds": {},
+              "f:replicas": {},
+              "f:revisionHistoryLimit": {},
+              "f:selector": {},
+              "f:strategy": {
+                "f:rollingUpdate": {
+                  ".": {},
+                  "f:maxSurge": {},
+                  "f:maxUnavailable": {}
+                },
+                "f:type": {}
+              },
+              "f:template": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:app": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2024-01-11T12:25:50Z"
+        }
+      ],
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "0663a366-270c-4d7c-a483-6f59d200fb22"
+    },
+    "spec": {
+      "progressDeadlineSeconds": 600,
+      "replicas": 0,
+      "revisionHistoryLimit": 10,
+      "selector": {
+        "matchLabels": {
+          "app": "nginx"
+        }
+      },
+      "strategy": {
+        "rollingUpdate": {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%"
+        },
+        "type": "RollingUpdate"
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "nginx"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx:latest",
+              "imagePullPolicy": "Always",
+              "name": "nginx",
+              "ports": [
+                {
+                  "containerPort": 80,
+		  "protocol": "TCP"
+		}
+	      ],
+	      "resources": {
+		      "requests": {
+			      "cpu": "1",
+			      "memory": "250Mi"
+		      },
+		      "limits": {
+			      "cpu": "1"
+		      }
+	      },
+	      "terminationMessagePath": "/dev/termination-log",
+	      "terminationMessagePolicy": "File"
+	    }
+	  ],
+	  "dnsPolicy": "ClusterFirst",
+	  "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  "operation": "CREATE",
+  "options": {
+    "apiVersion": "meta.k8s.io/v1",
+    "fieldManager": "kubectl-client-side-apply",
+    "fieldValidation": "Strict",
+    "kind": "CreateOptions"
+  },
+  "requestKind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "requestResource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "uid": "31403b86-f972-423e-8adb-c4bd79dc15cc",
+  "userInfo": {
+    "groups": [
+      "system:masters",
+      "system:authenticated"
+    ],
+    "username": "system:admin"
+  }
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -81,17 +81,18 @@ func TestContainerIsRequiredToHaveLimits(t *testing.T) {
 					"memory": &oneGiMemoryQuantity,
 				},
 			}, true, ""},
-		{"no cpu limit", corev1.Container{
-			Resources: &corev1.ResourceRequirements{
-				Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
-					"memory": &oneGiMemoryQuantity,
-				},
-				Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
-					"cpu":    &oneCoreCpuQuantity,
-					"memory": &oneGiMemoryQuantity,
+		{"no cpu limit",
+			corev1.Container{
+				Resources: &corev1.ResourceRequirements{
+					Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"memory": &oneGiMemoryQuantity,
+					},
+					Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"cpu":    &oneCoreCpuQuantity,
+						"memory": &oneGiMemoryQuantity,
+					},
 				},
 			},
-		},
 
 			Settings{
 				Cpu: &ResourceConfiguration{
@@ -359,21 +360,21 @@ func TestContainerIsRequiredToHaveLimits(t *testing.T) {
 				MaxLimit:       oneCore,
 			},
 			Memory: &ResourceConfiguration{
-				IgnoreValues: true,
+				IgnoreValues:   true,
 				DefaultLimit:   oneGi,
 				DefaultRequest: oneGi,
 				MaxLimit:       oneGi,
 			},
 		}, &corev1.ResourceRequirements{
-				Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
-					"memory": &twoGiMemoryQuantity,
-					"cpu":    &twoCoreCpuQuantity,
-				},
-				Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
-					"memory": &twoGiMemoryQuantity,
-					"cpu":    &twoCoreCpuQuantity,
-				},
-		}, false,  "cpu limit '2' exceeds the max allowed value '1'"},
+			Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+				"memory": &twoGiMemoryQuantity,
+				"cpu":    &twoCoreCpuQuantity,
+			},
+			Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+				"memory": &twoGiMemoryQuantity,
+				"cpu":    &twoCoreCpuQuantity,
+			},
+		}, false, "cpu limit '2' exceeds the max allowed value '1'"},
 		{"memory exceeds limit while ignore cpu values", corev1.Container{
 			Resources: &corev1.ResourceRequirements{
 				Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
@@ -387,7 +388,7 @@ func TestContainerIsRequiredToHaveLimits(t *testing.T) {
 			},
 		}, Settings{
 			Cpu: &ResourceConfiguration{
-				IgnoreValues: true,
+				IgnoreValues:   true,
 				DefaultLimit:   oneCore,
 				DefaultRequest: oneCore,
 				MaxLimit:       oneCore,
@@ -398,15 +399,85 @@ func TestContainerIsRequiredToHaveLimits(t *testing.T) {
 				MaxLimit:       oneGi,
 			},
 		}, &corev1.ResourceRequirements{
+			Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+				"memory": &twoGiMemoryQuantity,
+				"cpu":    &twoCoreCpuQuantity,
+			},
+			Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+				"memory": &twoGiMemoryQuantity,
+				"cpu":    &twoCoreCpuQuantity,
+			},
+		}, false, "memory limit '2Gi' exceeds the max allowed value '1Gi'"},
+		{"no memory limit and request greater then the default limit value",
+			corev1.Container{
+				Resources: &corev1.ResourceRequirements{
+					Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"cpu": &oneCoreCpuQuantity,
+					},
+					Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"cpu":    &oneCoreCpuQuantity,
+						"memory": &twoGiMemoryQuantity,
+					},
+				},
+			},
+
+			Settings{
+				Cpu: &ResourceConfiguration{
+					DefaultLimit:   oneCore,
+					DefaultRequest: oneCore,
+					MaxLimit:       oneCore,
+				},
+				Memory: &ResourceConfiguration{
+					DefaultLimit:   oneGi,
+					DefaultRequest: oneGi,
+					MaxLimit:       oneGi,
+				},
+				IgnoreImages: []string{},
+			}, &corev1.ResourceRequirements{
 				Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
-					"memory": &twoGiMemoryQuantity,
-					"cpu":    &twoCoreCpuQuantity,
+					"cpu":    &oneCoreCpuQuantity,
+					"memory": &oneGiMemoryQuantity,
 				},
 				Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+					"cpu":    &oneCoreCpuQuantity,
 					"memory": &twoGiMemoryQuantity,
-					"cpu":    &twoCoreCpuQuantity,
 				},
-		}, false, "memory limit '2Gi' exceeds the max allowed value '1Gi'"},
+			}, false, "memory limit '1Gi' is less than the requested '2Gi' value"},
+		{"no cpu limit and request greater then the default limit value",
+			corev1.Container{
+				Resources: &corev1.ResourceRequirements{
+					Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"memory": &oneGiMemoryQuantity,
+					},
+					Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+						"cpu":    &twoCoreCpuQuantity,
+						"memory": &oneGiMemoryQuantity,
+					},
+				},
+			},
+
+			Settings{
+				Cpu: &ResourceConfiguration{
+					DefaultLimit:   oneCore,
+					DefaultRequest: oneCore,
+					MaxLimit:       oneCore,
+				},
+				Memory: &ResourceConfiguration{
+					DefaultLimit:   oneGi,
+					DefaultRequest: oneGi,
+					MaxLimit:       oneGi,
+				},
+				IgnoreImages: []string{},
+			}, &corev1.ResourceRequirements{
+				Limits: map[string]*apimachinery_pkg_api_resource.Quantity{
+					"memory": &oneGiMemoryQuantity,
+					"cpu":    &oneCoreCpuQuantity,
+				},
+				Requests: map[string]*apimachinery_pkg_api_resource.Quantity{
+					"cpu":    &twoCoreCpuQuantity,
+					"memory": &oneGiMemoryQuantity,
+				},
+			}, false, "cpu limit '1' is less than the requested '2' value"},
 	}
 
 	for _, test := range tests {
@@ -420,15 +491,14 @@ func TestContainerIsRequiredToHaveLimits(t *testing.T) {
 					t.Fatalf("expected error message with string '%s'. But no error has been returned", test.expectedErrorMsg)
 				}
 				if !strings.Contains(err.Error(), test.expectedErrorMsg) {
-					t.Errorf("invalid error message. Expected the string '%s' in the error. Got '%s'", test.expectedErrorMsg, err.Error())
+					t.Fatalf("invalid error message. Expected the string '%s' in the error. Got '%s'", test.expectedErrorMsg, err.Error())
 				}
 			}
 			if mutated != test.shouldMutate {
-				t.Errorf("validation function does not report mutation flag correctly. Got: %t, expected: %t", mutated, test.shouldMutate)
+				t.Fatalf("validation function does not report mutation flag correctly. Got: %t, expected: %t", mutated, test.shouldMutate)
 			}
 			if diff := cmp.Diff(test.container.Resources, test.expectedResouceLimits); diff != "" {
-				t.Logf("%+v", test.container.Resources)
-				t.Error(diff)
+				t.Fatalf(diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The policy adds resource limits when they are missing in the containers. However, depending the requested resources and the policy configuration the users can hit a scenario where the policy mutates the resource adding a limit which is less than the requested resource. Therefore, Kubernetes will complain about it. To avoid this issue, the policy checks if the result of the mutation is valid. If it's not, reject the request to force the user to change the minimum request resource amount or adjust the policy configuration.

Fix #52 
